### PR TITLE
Fix file descriptor closing & use codecs library to open the files.

### DIFF
--- a/dependency_graph.py
+++ b/dependency_graph.py
@@ -1,6 +1,7 @@
 import os
 import re
 import argparse
+import codecs
 from collections import defaultdict
 from graphviz import Digraph
 
@@ -33,8 +34,9 @@ def find_all_files(path, recursive=True):
 
 def find_neighbors(path):
 	""" Find all the other nodes included by the file targeted by path. """
-	f = open(path)
+	f = codecs.open(path, 'r', "utf-8", "ignore")
 	code = f.read()
+	f.close()
 	return [normalize(include) for include in include_regex.findall(code)]
 
 def create_graph(folder, create_cluster):


### PR DESCRIPTION
I bumped into issues with some non-utf-8 projects: 
https://github.com/orocos-toolchain/rtt/blob/49752330ac2290ffb5206d42245ace716e2d93db/rtt/marsh/tinystr.cpp#L64

```bash
$ file -bi ~/tools/rtt/rtt/marsh/tinystr.cpp 
text/x-c++; charset=iso-8859-1
```

The default python `open` tries to parse the file as UTF-8 but the `ø` character then fails to be decoded and the software throws.

With this workaround, all these characters will be removed before processing. NOTE: This happened in many projects, mainly due to commented code (licenses).