### PR TITLE
Make it an installable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,33 @@ It is useful to check the presence of circular dependencies.
 
 ## Installation
 
-The script depends on [Graphviz](https://www.graphviz.org/) to draw the graph. 
+The script depends on [Graphviz](https://www.graphviz.org/) to draw the graph.
 
-On Ubuntu, you can install the dependencies with these two commands:
+On Ubuntu, you can install it with:
 
 ```
 sudo apt install graphviz
-pip3 install -r requirements.txt
+```
+
+Then, install the script with and run it with:
+
+```
+pip install git+https://github.com/pvigier/dependency-graph
+cpp_dependency_graph
+```
+
+Or, if you want to run it without installing:
+
+```
+pip install -r requirements.txt
+python3 -m cpp_dependency_graph
 ```
 
 ## Manual
 
 ```
-usage: dependency_graph.py [-h] [-f {bmp,gif,jpg,png,pdf,svg}] [-v] [-c]
-                           folder output
+usage: cpp_dependency_graph [-h] [-f {bmp,gif,jpg,png,pdf,svg}] [-v] [-c]
+                            folder output
 
 positional arguments:
   folder                Path to the folder to scan

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ On Ubuntu, you can install it with:
 sudo apt install graphviz
 ```
 
-Then, install the script with and run it with:
+Then, install the script and run it with:
 
 ```
 pip install git+https://github.com/pvigier/dependency-graph

--- a/cpp_dependency_graph/__main__.py
+++ b/cpp_dependency_graph/__main__.py
@@ -1,0 +1,3 @@
+from cpp_dependency_graph.main import main
+
+main()

--- a/cpp_dependency_graph/graph.py
+++ b/cpp_dependency_graph/graph.py
@@ -1,6 +1,5 @@
 import os
 import re
-import argparse
 import codecs
 from collections import defaultdict
 from graphviz import Digraph
@@ -22,7 +21,7 @@ def get_extension(path):
 	return path[path.rfind('.'):]
 
 def find_all_files(path, recursive=True):
-	""" 
+	"""
 	Return a list of all the files in the folder.
 	If recursive is True, the function will search recursively.
 	"""
@@ -73,18 +72,3 @@ def create_graph(folder, create_cluster, label_cluster, strict):
 			if create_cluster and label_cluster:
 				cluster.attr(label=folder)
 	return graph
-
-if __name__ == '__main__':
-	parser = argparse.ArgumentParser()
-	parser.add_argument('folder', help='Path to the folder to scan')
-	parser.add_argument('output', help='Path of the output file without the extension')
-	parser.add_argument('-f', '--format', help='Format of the output', default='pdf', \
-		choices=['bmp', 'gif', 'jpg', 'png', 'pdf', 'svg'])
-	parser.add_argument('-v', '--view', action='store_true', help='View the graph')
-	parser.add_argument('-c', '--cluster', action='store_true', help='Create a cluster for each subfolder')
-	parser.add_argument('--cluster-labels', dest='cluster_labels', action='store_true', help='Label subfolder clusters')
-	parser.add_argument('-s', '--strict', action='store_true', help='Rendering should merge multi-edges', default=False)
-	args = parser.parse_args()
-	graph = create_graph(args.folder, args.cluster, args.cluster_labels, args.strict)
-	graph.format = args.format
-	graph.render(args.output, cleanup=True, view=args.view)

--- a/cpp_dependency_graph/main.py
+++ b/cpp_dependency_graph/main.py
@@ -1,0 +1,17 @@
+import argparse
+from cpp_dependency_graph.graph import create_graph
+
+def main():
+	parser = argparse.ArgumentParser()
+	parser.add_argument('folder', help='Path to the folder to scan')
+	parser.add_argument('output', help='Path of the output file without the extension')
+	parser.add_argument('-f', '--format', help='Format of the output', default='pdf', \
+		choices=['bmp', 'gif', 'jpg', 'png', 'pdf', 'svg'])
+	parser.add_argument('-v', '--view', action='store_true', help='View the graph')
+	parser.add_argument('-c', '--cluster', action='store_true', help='Create a cluster for each subfolder')
+	parser.add_argument('--cluster-labels', dest='cluster_labels', action='store_true', help='Label subfolder clusters')
+	parser.add_argument('-s', '--strict', action='store_true', help='Rendering should merge multi-edges', default=False)
+	args = parser.parse_args()
+	graph = create_graph(args.folder, args.cluster, args.cluster_labels, args.strict)
+	graph.format = args.format
+	graph.render(args.output, cleanup=True, view=args.view)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cpp_dependency_graph"
+version = "1.0.0"
+dependencies = [
+    "graphviz",
+]
+
+[project.scripts]
+cpp_dependency_graph = "cpp_dependency_graph.main:main"


### PR DESCRIPTION
For it is much more convenient to install it and run it from anywhere on the computer as `cpp_dependency_graph` than just being able to run the .py file

Edit: it's still possible to run it without installing of course, see the [updated instructions](https://github.com/victorbnl/dependency-graph/tree/package#installation)