### PR TITLE
Fixed a bug and add some features

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The original version does not work properly when files from different directorie
 
 --ignore-tests argument adds ignoring to files with names that includes "test".
 
+--show-path argument adds path in nodes labels.
+
 ## Installation
 
 The script depends on [Graphviz](https://www.graphviz.org/) to draw the graph. 
@@ -48,6 +50,7 @@ options:
   --text                Create graph.txt with filenames and edges
   --lines               Add to graph.txt number of lines in files
   --ignore-tests        Files with names that includes "test" will be ignored in graph
+  --show-path           Files will be labeled with path
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ It is useful to check the presence of circular dependencies.
 
 ## Differences from original version
 
-The original version does not work correctly when the source and header files have the same names. This has been fixed in this version.
+The original version does not work properly when files from different directories have the same names or when the source and header files have the same names. This has been fixed in this version.
 
-The --gv argument has been added, which generates a graph.gv file with a graph for use in third-party applications.
+--gv argument generates a graph.gv file with a graph for use in third-party applications.
 
-The --text argument has been added, which generates a graph.txt file with a text file containing graph data.
+--text argument generates a graph.txt file with a text file containing graph data.
 
-Added the --line argument, which adds information about the number of lines in files in graph.txt (Requires the --text argument)
+--line argument adds information about the number of lines in files in graph.txt (Requires the --text argument).
+
+--ignore-tests argument adds ignoring to files with names that includes "test".
 
 ## Installation
 
@@ -28,7 +30,7 @@ pip3 install -r requirements.txt
 ## Manual
 
 ```
-usage: dependency_graph.py [-h] [-f {bmp,gif,jpg,png,pdf,svg}] [-v] [-c] [--cluster-labels] [-s] [--gv] [--text] [--lines] folder output
+usage: dependency_graph.py [-h] [-f {bmp,gif,jpg,png,pdf,svg}] [-v] [-c] [--cluster-labels] [-s] [--gv] [--text] [--lines] [--ignore-tests] folder output
 
 positional arguments:
   folder                Path to the folder to scan
@@ -45,6 +47,7 @@ options:
   --gv                  Create graph.gv
   --text                Create graph.txt with filenames and edges
   --lines               Add to graph.txt number of lines in files
+  --ignore-tests        Files with names that includes "test" will be ignored in graph
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ A python script to show the "include" dependency of C++ classes.
 
 It is useful to check the presence of circular dependencies.
 
+## Differences from original version
+
+The original version does not work correctly when the source and header files have the same names. This has been fixed in this version.
+
+The --gv argument has been added, which generates a graph.gv file with a graph for use in third-party applications.
+
+The --text argument has been added, which generates a graph.txt file with a text file containing graph data.
+
+Added the --line argument, which adds information about the number of lines in files in graph.txt (Requires the --text argument)
+
 ## Installation
 
 The script depends on [Graphviz](https://www.graphviz.org/) to draw the graph. 
@@ -18,19 +28,23 @@ pip3 install -r requirements.txt
 ## Manual
 
 ```
-usage: dependency_graph.py [-h] [-f {bmp,gif,jpg,png,pdf,svg}] [-v] [-c]
-                           folder output
+usage: dependency_graph.py [-h] [-f {bmp,gif,jpg,png,pdf,svg}] [-v] [-c] [--cluster-labels] [-s] [--gv] [--text] [--lines] folder output
 
 positional arguments:
   folder                Path to the folder to scan
   output                Path of the output file without the extension
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -f {bmp,gif,jpg,png,pdf,svg}, --format {bmp,gif,jpg,png,pdf,svg}
                         Format of the output
   -v, --view            View the graph
   -c, --cluster         Create a cluster for each subfolder
+  --cluster-labels      Label subfolder clusters
+  -s, --strict          Rendering should merge multi-edges
+  --gv                  Create graph.gv
+  --text                Create graph.txt with filenames and edges
+  --lines               Add to graph.txt number of lines in files
 ```
 
 ## Examples

--- a/dependency_graph.py
+++ b/dependency_graph.py
@@ -61,7 +61,7 @@ def create_graph(folder, create_cluster, label_cluster, strict, gv, text, lines)
 	
 	files_to_numbers = defaultdict(int)
 	if text:
-		str_lines = ['']
+		str_lines = ['', 'Nodes:\n']
 		for i in range(len(files)):
 			normalized_name = normalize(files[i]) + get_extension(files[i]) 
 			if lines:
@@ -69,6 +69,7 @@ def create_graph(folder, create_cluster, label_cluster, strict, gv, text, lines)
 			else:
 				str_lines.append(f'{i + 1} {normalized_name}\n')
 			files_to_numbers[normalized_name] = i + 1
+		str_lines.append('Edges:\n')
 	if gv:
 		gv_lines = []
 		gv_lines.append('digraph ' + str(normalize(folder)) + ' {\n')
@@ -112,7 +113,7 @@ def create_graph(folder, create_cluster, label_cluster, strict, gv, text, lines)
 					gv_lines.append('\t}\n')
 	if text:
 		with open('graph.txt', mode='w') as file:
-			str_lines[0] = f'{len(files)} {len(str_lines) - len(files) - 1}\n'
+			str_lines[0] = f'Nodes count: {len(files)} Edges count: {len(str_lines) - len(files) - 3}\n'
 			file.writelines(str_lines)
 	if gv:
 		with open('graph.gv', mode='w') as file:


### PR DESCRIPTION
Fixed a bug where the graph was built incorrectly when different files in project had the same names.
Add some additional features:
--gv                        Create graph.gv files with this extension that can be used in third-party applications
--text                      Create graph.txt with filenames, nodes and edges
--lines                     Add to graph.txt number of lines in files
--ignore-tests         Files with names including "test" will be ignored in the graph. Ideal for analyzing large projects
